### PR TITLE
CTCTRADERS-2779 Fix placement of back button

### DIFF
--- a/.g8/checkboxPage/conf/views/$className__decap$.njk
+++ b/.g8/checkboxPage/conf/views/$className__decap$.njk
@@ -10,13 +10,16 @@
   {{ title(messages("$className;format="decap"$.title"), form.errors) }}
 {% endblock %}
 
-{% block mainContent %}
+{% block beforeContent %}
 
   {{ govukBackLink({
     text: messages("site.back")
   }) }}
 
-  <div class="govuk-main-wrapper">
+{% endblock %}
+
+{% block mainContent %}
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -50,7 +53,6 @@
 
         </form>
 
-      </div>
     </div>
   </div>
 

--- a/.g8/datePage/conf/views/$className__decap$.njk
+++ b/.g8/datePage/conf/views/$className__decap$.njk
@@ -10,13 +10,16 @@
   {{ title(messages("$className;format="decap"$.title"), form.errors) }}
 {% endblock %}
 
-{% block mainContent %}
+{% block beforeContent %}
 
   {{ govukBackLink({
     text: messages("site.back")
   }) }}
 
-  <div class="govuk-main-wrapper">
+{% endblock %}
+
+{% block mainContent %}
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -53,7 +56,6 @@
         </form>
 
       </div>
-    </div>
   </div>
 
 {% endblock %}

--- a/.g8/intPage/conf/views/$className__decap$.njk
+++ b/.g8/intPage/conf/views/$className__decap$.njk
@@ -10,13 +10,16 @@
   {{ title(messages("$className;format="decap"$.title"), form.errors) }}
 {% endblock %}
 
-{% block mainContent %}
+{% block beforeContent %}
 
   {{ govukBackLink({
     text: messages("site.back")
   }) }}
 
-  <div class="govuk-main-wrapper">
+{% endblock %}
+
+{% block mainContent %}
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -51,7 +54,6 @@
 
         </form>
 
-      </div>
     </div>
   </div>
 

--- a/.g8/optionsPage/conf/views/$className__decap$.njk
+++ b/.g8/optionsPage/conf/views/$className__decap$.njk
@@ -10,13 +10,16 @@
   {{ title(messages("$className;format="decap"$.title"), form.errors) }}
 {% endblock %}
 
-{% block mainContent %}
+{% block beforeContent %}
 
   {{ govukBackLink({
     text: messages("site.back")
   }) }}
 
-  <div class="govuk-main-wrapper">
+{% endblock %}
+
+{% block mainContent %}
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -50,7 +53,6 @@
 
         </form>
 
-      </div>
     </div>
   </div>
 

--- a/.g8/page/conf/views/$className__decap$.njk
+++ b/.g8/page/conf/views/$className__decap$.njk
@@ -8,7 +8,6 @@
 
 {% block mainContent %}
 
-  <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -18,6 +17,5 @@
 
       </div>
     </div>
-  </div>
 
 {% endblock %}

--- a/.g8/questionPage/conf/views/$className__decap$.njk
+++ b/.g8/questionPage/conf/views/$className__decap$.njk
@@ -10,13 +10,16 @@
   {{ title(messages("$className;format="decap"$.title"), form.errors) }}
 {% endblock %}
 
-{% block mainContent %}
+{% block beforeContent %}
 
   {{ govukBackLink({
     text: messages("site.back")
   }) }}
 
-  <div class="govuk-main-wrapper">
+{% endblock %}
+
+{% block mainContent %}
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -62,7 +65,6 @@
         </form>
 
       </div>
-    </div>
   </div>
 
 {% endblock %}

--- a/.g8/stringPage/conf/views/$className__decap$.njk
+++ b/.g8/stringPage/conf/views/$className__decap$.njk
@@ -10,13 +10,16 @@
   {{ title(messages("$className;format="decap"$.title"), form.errors) }}
 {% endblock %}
 
-{% block mainContent %}
+{% block beforeContent %}
 
   {{ govukBackLink({
     text: messages("site.back")
   }) }}
 
-  <div class="govuk-main-wrapper">
+{% endblock %}
+
+{% block mainContent %}
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -50,7 +53,6 @@
         </form>
 
       </div>
-    </div>
   </div>
 
 {% endblock %}

--- a/.g8/yesNoPage/conf/views/$className__decap$.njk
+++ b/.g8/yesNoPage/conf/views/$className__decap$.njk
@@ -10,13 +10,16 @@
   {{ title(messages("$className;format="decap"$.title"), form.errors) }}
 {% endblock %}
 
-{% block mainContent %}
+{% block beforeContent %}
 
   {{ govukBackLink({
     text: messages("site.back")
   }) }}
 
-  <div class="govuk-main-wrapper">
+{% endblock %}
+
+{% block mainContent %}
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -52,7 +55,6 @@
         </form>
 
       </div>
-    </div>
   </div>
 
 {% endblock %}

--- a/app/assets/stylesheets/partials/_shame.scss
+++ b/app/assets/stylesheets/partials/_shame.scss
@@ -33,20 +33,6 @@
 .lang {
     float: right;
 }
-.govuk-back-link {
-    float: left;
-    top: -40px;
-    margin-bottom: -40px;
-}
-@media screen and (max-width: 40.0624em){
-    .govuk-main-wrapper {
-        padding-top: 40px;
-    }
-}
-// clear float back link
-.govuk-back-link + .govuk-main-wrapper {
-    clear: both;
-}
 
 // ******************************************************
 // ******************************************************

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -75,7 +75,7 @@ eoriNumber.error.invalidFormat = Enter your EORI number in the right format, lik
 
 waitOnGuaranteeBalance.title = We are trying to get your guarantee balance
 waitOnGuaranteeBalance.heading = We are trying to get your guarantee balance
-waitOnGuaranteeBalance.paragraph = This may take up to {0} seconds
+waitOnGuaranteeBalance.paragraph = This may take up to {0} seconds.
 
 guaranteeReferenceNumber.title = What is the guarantee reference number?
 guaranteeReferenceNumber.heading = What is the guarantee reference number?

--- a/conf/views/accessCode.njk
+++ b/conf/views/accessCode.njk
@@ -10,13 +10,16 @@
   {{ title(messages("accessCode.title"), form.errors) }}
 {% endblock %}
 
-{% block mainContent %}
+{% block beforeContent %}
 
   {{ govukBackLink({
     text: messages("site.back")
   }) }}
 
-  <div class="govuk-main-wrapper">
+{% endblock %}
+
+{% block mainContent %}
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -58,6 +61,5 @@
 
       </div>
     </div>
-  </div>
 
 {% endblock %}

--- a/conf/views/balanceConfirmation.njk
+++ b/conf/views/balanceConfirmation.njk
@@ -9,7 +9,6 @@
 
 {% block mainContent %}
 
-  <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -38,6 +37,5 @@
 
       </div>
     </div>
-  </div>
 
 {% endblock %}

--- a/conf/views/checkYourAnswers.njk
+++ b/conf/views/checkYourAnswers.njk
@@ -11,7 +11,6 @@
 
 {% block mainContent %}
 
-  <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -37,6 +36,5 @@
 
       </div>
     </div>
-  </div>
 
 {% endblock %}

--- a/conf/views/detailsDontMatch.njk
+++ b/conf/views/detailsDontMatch.njk
@@ -8,7 +8,6 @@
 
 {% block mainContent %}
 
-  <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -20,6 +19,5 @@
 
       </div>
     </div>
-  </div>
 
 {% endblock %}

--- a/conf/views/eoriNumber.njk
+++ b/conf/views/eoriNumber.njk
@@ -10,13 +10,16 @@
   {{ title(messages("eoriNumber.title"), form.errors) }}
 {% endblock %}
 
-{% block mainContent %}
+{% block beforeContent %}
 
   {{ govukBackLink({
     text: messages("site.back")
   }) }}
 
-  <div class="govuk-main-wrapper">
+{% endblock %}
+
+{% block mainContent %}
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -51,7 +54,6 @@
         </form>
 
       </div>
-    </div>
   </div>
 
 {% endblock %}

--- a/conf/views/guaranteeReferenceNumber.njk
+++ b/conf/views/guaranteeReferenceNumber.njk
@@ -10,13 +10,16 @@
   {{ title(messages("guaranteeReferenceNumber.title"), form.errors) }}
 {% endblock %}
 
-{% block mainContent %}
+{% block beforeContent %}
 
   {{ govukBackLink({
     text: messages("site.back")
   }) }}
 
-  <div class="govuk-main-wrapper">
+{% endblock %}
+
+{% block mainContent %}
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -55,7 +58,6 @@
         </form>
 
       </div>
-    </div>
   </div>
 
 {% endblock %}

--- a/conf/views/rateLimit.njk
+++ b/conf/views/rateLimit.njk
@@ -9,7 +9,6 @@
 
 {% block mainContent %}
 
-  <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -30,6 +29,5 @@
 
       </div>
     </div>
-  </div>
 
 {% endblock %}

--- a/conf/views/session-expired.njk
+++ b/conf/views/session-expired.njk
@@ -10,7 +10,6 @@
 
 {% block mainContent %}
 
-  <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -31,6 +30,5 @@
 
       </div>
     </div>
-  </div>
 
 {% endblock %}

--- a/conf/views/technicalDifficulties.njk
+++ b/conf/views/technicalDifficulties.njk
@@ -8,7 +8,6 @@
 
 {% block mainContent %}
 
-  <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -29,7 +28,6 @@
         </p>
 
       </div>
-    </div>
   </div>
 
 {% endblock %}

--- a/conf/views/unauthorised.njk
+++ b/conf/views/unauthorised.njk
@@ -8,7 +8,6 @@
 
 {% block mainContent %}
 
-  <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
@@ -22,6 +21,5 @@
 
       </div>
     </div>
-  </div>
 
 {% endblock %}


### PR DESCRIPTION
- Remove unneeded double nesting of `.govuk-main-wrapper` css classes
- Remove css rules to fix double nesting in .shame.scss

Playback of backlink should be outside main tag:
https://design-system.service.gov.uk/components/back-link/#how-it-works

GOV.UK template layout already implements `.govuk-main-wrapper` and is unneeded in our views.
https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/template.njk#L48-L50