### PR TITLE
CTCTRADERS-2772 Fix a11y issue with skip to main content

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,7 +21,3 @@ $hmrc-assets-path: "/check-guarantee-balance/assets/lib/hmrc-frontend/hmrc/asset
 p {
     @extend .govuk-body;
 }
-
-a {
-    @extend .govuk-link;
-}

--- a/conf/views/balanceConfirmation.njk
+++ b/conf/views/balanceConfirmation.njk
@@ -14,7 +14,7 @@
 
         {{ govukPanel({
           titleText: messages("balanceConfirmation.heading"),
-          html: "<br><strong>" + balance + "</strong>"
+          html: "<strong>" + balance + "</strong>"
         }) }}
 
         {% switch referral %}
@@ -23,14 +23,14 @@
 
             <p>{{ messages("balanceConfirmation.fromNcts.p") }}</p>
             <ul class="govuk-list govuk-list--bullet">
-              <li><a href={{ checkAnotherGuaranteeBalanceUrl }} id="check-another-guarantee-balance">{{ messages("balanceConfirmation.fromNcts.link1") }}</a></li>
-              <li><a href={{ routes.controllers.BalanceConfirmationController.manageTransitMovements().url }} id="manage-transit-movements">{{ messages("balanceConfirmation.fromNcts.link2") }}</a></li>
+              <li><a class="govuk-link" href={{ checkAnotherGuaranteeBalanceUrl }} id="check-another-guarantee-balance">{{ messages("balanceConfirmation.fromNcts.link1") }}</a></li>
+              <li><a class="govuk-link" href={{ routes.controllers.BalanceConfirmationController.manageTransitMovements().url }} id="manage-transit-movements">{{ messages("balanceConfirmation.fromNcts.link2") }}</a></li>
             </ul>
 
           {% default %}
 
             <p>{{ messages("balanceConfirmation.fromGovUk.p") }}
-              <a href={{ checkAnotherGuaranteeBalanceUrl }} id="check-another-guarantee-balance">{{ messages("balanceConfirmation.fromGovUk.link") }}</a>.
+              <a class="govuk-link" href={{ checkAnotherGuaranteeBalanceUrl }} id="check-another-guarantee-balance">{{ messages("balanceConfirmation.fromGovUk.link") }}</a>.
             </p>
 
         {% endswitch %}

--- a/conf/views/detailsDontMatch.njk
+++ b/conf/views/detailsDontMatch.njk
@@ -15,7 +15,7 @@
           {{ messages("detailsDontMatch.heading") }}
         </h1>
 
-        <p>{{ messages("detailsDontMatch.youMust") }} <a id="try-again" href="{{ routes.controllers.CheckYourAnswersController.onPageLoad().url }}">{{ messages("detailsDontMatch.checkYourAnswers") }}</a>.</p>
+        <p>{{ messages("detailsDontMatch.youMust") }} <a class="govuk-link" id="try-again" href="{{ routes.controllers.CheckYourAnswersController.onPageLoad().url }}">{{ messages("detailsDontMatch.checkYourAnswers") }}</a>.</p>
 
       </div>
     </div>

--- a/conf/views/notFound.njk
+++ b/conf/views/notFound.njk
@@ -15,7 +15,7 @@
       <p class="govuk-body">{{ messages("pageNotFound.paragraph1") }}</p>
       <p class="govuk-body">{{ messages("pageNotFound.paragraph2") }}</p>
       <p class="govuk-body">{{ messages("pageNotFound.paragraph3Start") }}
-        <a href={{ config.nctsUrl }} target="_blank" id="contact" rel="noopener noreferrer">{{ messages("pageNotFound.contactLink") }}</a>.
+        <a class="govuk-link" href={{ config.nctsUrl }} target="_blank" id="contact" rel="noopener noreferrer">{{ messages("pageNotFound.contactLink") }}</a>.
       </p>
 
    </div>


### PR DESCRIPTION
- Balance confirmation used a `<br/>` element which was not needed
- Removed override rule for anchor/link elements which broke skip to main content

**Skip to main content**
Before:
<img width="923" alt="Screenshot 2021-11-19 at 12 13 10" src="https://user-images.githubusercontent.com/2979782/142623737-e910f53a-1021-4919-b2c2-90723c7dcb12.png">
After:
<img width="901" alt="Screenshot 2021-11-19 at 12 13 25" src="https://user-images.githubusercontent.com/2979782/142623770-49f1ef65-35bb-4ed1-af9d-cf5214838f2a.png">


