### PR TITLE
CTCP-2893 | Refactor to render correctly where there is no currency code in the API response. Solution is currency code agnostic.

### DIFF
--- a/app/models/backend/BalanceRequestResponse.scala
+++ b/app/models/backend/BalanceRequestResponse.scala
@@ -32,23 +32,19 @@ case class BalanceRequestSuccess(
   currency: Option[CurrencyCode]
 ) extends BalanceRequestResponse {
 
-  private def roundUp(balance: BigDecimal): BigDecimal = balance.setScale(2, BigDecimal.RoundingMode.UP)
-
-  def formatForDisplay: String = {
-    val currencyCode: String = currency.map(_.value).getOrElse("")
-
+  def formatForDisplay: String =
     try {
       val formatter = NumberFormat.getCurrencyInstance(Locale.UK)
-      formatter.setCurrency(Currency.getInstance(currencyCode))
+      if (currency.isDefined) {
+        formatter.setCurrency(Currency.getInstance(currency.get.value))
+      }
       formatter.format(balance)
     } catch {
       case _: Exception =>
-        // TODO = round up here?
-        currency.fold(s"$currencyCode${roundUp(balance)}")(
-          _ => s"$currencyCode$balance"
+        currency.fold(s"$balance")(
+          x => s"${x.value}$balance"
         )
     }
-  }
 }
 
 case class BalanceRequestPending(balanceId: BalanceId) extends BalanceRequestResponse

--- a/app/models/backend/BalanceRequestResponse.scala
+++ b/app/models/backend/BalanceRequestResponse.scala
@@ -35,7 +35,7 @@ case class BalanceRequestSuccess(
   def formatForDisplay: String =
     try {
       val formatter = NumberFormat.getCurrencyInstance(Locale.UK)
-      if (currency.isDefined) {
+      if (currency.nonEmpty) {
         formatter.setCurrency(Currency.getInstance(currency.get.value))
       }
       formatter.format(balance)

--- a/app/models/backend/BalanceRequestResponse.scala
+++ b/app/models/backend/BalanceRequestResponse.scala
@@ -32,6 +32,8 @@ case class BalanceRequestSuccess(
   currency: Option[CurrencyCode]
 ) extends BalanceRequestResponse {
 
+  private def roundUp(balance: BigDecimal): BigDecimal = balance.setScale(2, BigDecimal.RoundingMode.UP)
+
   def formatForDisplay: String = {
     val currencyCode: String = currency.map(_.value).getOrElse("")
 
@@ -41,7 +43,10 @@ case class BalanceRequestSuccess(
       formatter.format(balance)
     } catch {
       case _: Exception =>
-        s"$currencyCode$balance"
+        // TODO = round up here?
+        currency.fold(s"$currencyCode${roundUp(balance)}")(
+          _ => s"$currencyCode$balance"
+        )
     }
   }
 }

--- a/app/views/v2/BalanceConfirmationViewV2.scala.html
+++ b/app/views/v2/BalanceConfirmationViewV2.scala.html
@@ -32,7 +32,7 @@
 
     @govukPanel(Panel(
         title = Text(messages("balanceConfirmation.v2.heading")),
-        content = HtmlContent(s"""<strong>${balance}</strong><p>${messages("balanceConfirmation.v2.currency.p")}</p>"""),
+        content = HtmlContent(s"""<strong>${balance}</strong>"""),
         classes = "break-all"
     ))
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -151,7 +151,6 @@ balanceConfirmation.v2.fromGovUk.link = Check another guarantee balance
 balanceConfirmation.v2.fromNcts.p = You can:
 balanceConfirmation.v2.fromNcts.link1 = Check another guarantee balance
 balanceConfirmation.v2.fromNcts.link2 = Manage your transit movements
-balanceConfirmation.v2.currency.p = This balance is in the same currency selected for the liability amount.
 
 detailsDontMatch.title = Your details do not match our records
 detailsDontMatch.heading = Your details do not match our records

--- a/test/connectors/GuaranteeBalanceConnectorSpec.scala
+++ b/test/connectors/GuaranteeBalanceConnectorSpec.scala
@@ -541,7 +541,7 @@ class GuaranteeBalanceConnectorSpec extends SpecBase with WireMockServerHandler 
 
     "submitBalanceRequestV2" - {
 
-      "must return balance success response for Ok" in {
+      "must return balance success response for Ok no currency" in {
         val balanceRequestSuccessResponseJson: String =
           """
             | {
@@ -557,6 +557,28 @@ class GuaranteeBalanceConnectorSpec extends SpecBase with WireMockServerHandler 
         )
 
         val expectedResponse = BalanceRequestSuccess(BigDecimal(3.14), None)
+
+        val result = connector.submitBalanceRequestV2(requestV2, grn.value).futureValue
+        result mustBe Right(expectedResponse)
+      }
+
+      "must return balance success response for Ok with a currency" in {
+        val balanceRequestSuccessResponseJson: String =
+          """
+            | {
+            |   "balance": 3.14,
+            |   "currency": "GBP"
+            | }
+            |""".stripMargin
+
+        server.stubFor(
+          post(urlEqualTo(submitBalanceRequestV2Url(grn.value)))
+            .withHeader(HeaderNames.ACCEPT, equalTo("application/vnd.hmrc.2.0+json"))
+            .withRequestBody(equalToJson(requestV2AsJsonString))
+            .willReturn(okJson(balanceRequestSuccessResponseJson))
+        )
+
+        val expectedResponse = BalanceRequestSuccess(BigDecimal(3.14), Some(CurrencyCode("GBP")))
 
         val result = connector.submitBalanceRequestV2(requestV2, grn.value).futureValue
         result mustBe Right(expectedResponse)

--- a/test/models/backend/BalanceRequestResponseSpec.scala
+++ b/test/models/backend/BalanceRequestResponseSpec.scala
@@ -31,13 +31,13 @@ class BalanceRequestResponseSpec extends SpecBase {
 
       "must display currencies correctly for different currency codes" - {
 
-        "when not present" - {
+        "when not present defaults to pounds sterling" - {
 
           val currency: Option[CurrencyCode] = None
 
           "when balance of 10" in {
             val balance = BalanceRequestSuccess(10, currency)
-            balance.formatForDisplay mustEqual "10.00"
+            balance.formatForDisplay mustEqual "£10.00"
           }
         }
 

--- a/test/models/backend/BalanceRequestResponseSpec.scala
+++ b/test/models/backend/BalanceRequestResponseSpec.scala
@@ -31,6 +31,16 @@ class BalanceRequestResponseSpec extends SpecBase {
 
       "must display currencies correctly for different currency codes" - {
 
+        "when not present" - {
+
+          val currency: Option[CurrencyCode] = None
+
+          "when balance of 10" in {
+            val balance = BalanceRequestSuccess(10, currency)
+            balance.formatForDisplay mustEqual "10.00"
+          }
+        }
+
         "when pounds sterling" - {
 
           val currency: Option[CurrencyCode] = Some(CurrencyCode("GBP"))

--- a/test/views/v2/BalanceConfirmationViewV2Spec.scala
+++ b/test/views/v2/BalanceConfirmationViewV2Spec.scala
@@ -40,7 +40,7 @@ class BalanceConfirmationViewV2Spec extends PanelViewBehaviours {
 
   behave like pageWithHeading()
 
-  behave like pageWithPanel(s"$balance This balance is in the same currency selected for the liability amount.")
+  behave like pageWithPanel(s"$balance")
 
   "when NCTS referral" - {
     val view = injector.instanceOf[BalanceConfirmationViewV2].apply(balance, Some(NCTS.toString))(fakeRequest, messages)


### PR DESCRIPTION
The currency should always be returned however, this change will default to pounds sterling if there is no currency supplied by the API. 